### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/mc-cloud-town/VelocityCT/security/code-scanning/2](https://github.com/mc-cloud-town/VelocityCT/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to the workflow. The best practice is to set the minimal required permissions. In this workflow, the only step that requires more than `contents: read` is the "Create GitHub Release" step, which needs `contents: write`. Therefore, set `permissions: contents: write` at the job level for the `build` job. This ensures that the `GITHUB_TOKEN` used in the workflow has only the necessary permissions, adhering to the principle of least privilege. The change should be made by adding the following block under the `build:` job definition (after line 10 and before `runs-on:` on line 11).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
