### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Gradle Build
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/mc-cloud-town/VelocityCT/security/code-scanning/1](https://github.com/mc-cloud-town/VelocityCT/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code, builds, and uploads artifacts, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow (just after the `name` and before `on:`), so it applies to all jobs. No other permissions are needed for the shown steps.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
